### PR TITLE
Suppress some warnings in C++

### DIFF
--- a/cpp/Dockerfile
+++ b/cpp/Dockerfile
@@ -31,6 +31,8 @@ WORKDIR /home/code_runner
 
 # Directory for task launching
 RUN mkdir /home/code_runner/task 
+
+# ut.hpp: https://github.com/boost-ext/ut?tab=readme-ov-file
 COPY task/run-task.sh task/CMakeLists.txt task/ut.hpp task/test_helpers.h /home/code_runner/task/
 
 # Directory for playground

--- a/cpp/task/CMakeLists.txt
+++ b/cpp/task/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(STD_MODULE_FILE /usr/local/lib/std.pcm)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Werror -Wall -O2 -fmodule-file=std=${STD_MODULE_FILE}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Werror -Wall -Wno-unused-variable -Wno-logical-op-parentheses -O2 -fmodule-file=std=${STD_MODULE_FILE}")
 
 
 IF (EXISTS "/home/code_runner/task/main.cpp")


### PR DESCRIPTION
1. Добавлен коммент про то, откуда мы взяли тесты.
2. Подавляем ворнинги для неиспользуемых переменных.
3. Подавляем ворнинги про скобки (которые не нужны, но типа полезны). Пример:

Хорошо:

```c++
bool hello_xor(bool x, bool y) {
    return (x == true && y == false) || (x == false && y == true);
}
```

Плохо:

```c++
bool hello_xor(bool x, bool y) {
    return x == true && y == false || x == false && y == true;
}
```